### PR TITLE
Merge feature-site-name into develop

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -303,6 +303,29 @@ function uri_modern_people_page_template( $template ) {
 add_filter( 'template_include', 'uri_modern_people_page_template', 99 );
 
 
+function uri_modern_show_alternate_site_title_tagline() {
+    if ( get_option('site_header_alternate_titles_hide_tagline') && uri_modern_use_alternate_site_title() ) {
+        return false;
+    } else {
+        return true;
+    }
+}
+
+
+function uri_modern_use_alternate_site_title() {
+    $url = get_site_url();
+    $permalink = get_permalink();
+
+    $whitelist = explode(PHP_EOL, get_option('site_header_alternate_titles') );
+
+    foreach($whitelist as $w) {
+        if ($url . $w == $permalink || $url . $w . '/' == $permalink ) {
+            return true;
+            break;
+        }
+    }
+}
+
 
 /**
  * Debugging

--- a/functions.php
+++ b/functions.php
@@ -303,6 +303,13 @@ function uri_modern_people_page_template( $template ) {
 add_filter( 'template_include', 'uri_modern_people_page_template', 99 );
 
 
+/**
+ * Determine if the tagline should show on pages using
+ * the page title in place of the site name in the header.
+ *
+ * @see inc/customizer.php
+ * @return bool
+ */
 function uri_modern_show_alternate_site_title_tagline() {
     if ( get_option('site_header_alternate_titles_hide_tagline') && uri_modern_use_alternate_site_title() ) {
         return false;
@@ -312,6 +319,13 @@ function uri_modern_show_alternate_site_title_tagline() {
 }
 
 
+/**
+ * Determine if the page should use the page title in
+ * place of the site name in the header
+ *
+ * @see inc/customizer.php
+ * @return bool
+ */
 function uri_modern_use_alternate_site_title() {
     $url = get_site_url();
     $permalink = get_permalink();

--- a/header-parts/sitebar.php
+++ b/header-parts/sitebar.php
@@ -35,13 +35,14 @@
                         );
                     
                     $url = get_permalink();
-                                        
+                    
+                    $usetitle = false;
                     foreach($bases as $b) {
                         foreach($pages as $p) {
                             $test = $b . $p . '/';
                             if ($url == $test) {
                                 $usetitle = true;
-                                return;
+                                break;
                             }
                         }
                     }

--- a/header-parts/sitebar.php
+++ b/header-parts/sitebar.php
@@ -20,21 +20,8 @@
             <h1 class="site-title">
                 <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
                     <?php 
-                    
-                    $site_url = get_site_url();
-                    $site_permalink = get_permalink();
-                                        
-                    $alt_title_whitelist = explode(PHP_EOL, get_option('site_header_alternate_titles') );
-                                        
-                    $use_alt_title = false;
-                    foreach($alt_title_whitelist as $a) {
-                        if ($site_url . $a == $site_permalink || $site_url . $a . '/' == $site_permalink ) {
-                            $use_alt_title = true;
-                            break;
-                        }
-                    }
 
-                    if ($use_alt_title) {
+                    if (uri_modern_use_alternate_site_title()) {
                         the_title();
                     } else {
                         bloginfo( 'name' );
@@ -44,7 +31,7 @@
                 </a>
             </h1>
             <?php $description = get_bloginfo( 'description', 'display' );
-            if ( $description || is_customize_preview() ) : ?>
+            if ( uri_modern_show_alternate_site_title_tagline() && $description || is_customize_preview() ) : ?>
                 <h2 class="site-description"><?php echo $description; /* WPCS: xss ok. */ ?></h2>
             <?php
             endif; ?>

--- a/header-parts/sitebar.php
+++ b/header-parts/sitebar.php
@@ -17,7 +17,44 @@
 
         <div id="siteidentity">
             
-            <h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
+            <h1 class="site-title">
+                <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
+                    <?php 
+                    
+                    $bases = array(
+                        'https://www.uri.edu',
+                        'http://quack.uri.edu'
+                        );
+                    
+                    $pages = array(
+                        '/admissions',
+                        '/academics',
+                        '/research',
+                        '/campus-life',
+                        '/about'
+                        );
+                    
+                    $url = get_permalink();
+                                        
+                    foreach($bases as $b) {
+                        foreach($pages as $p) {
+                            $test = $b . $p . '/';
+                            if ($url == $test) {
+                                $usetitle = true;
+                                return;
+                            }
+                        }
+                    }
+                    
+                    if ($usetitle) {
+                        the_title();
+                    } else {
+                        bloginfo( 'name' );
+                    }
+                    
+                    ?>
+                </a>
+            </h1>
             <?php $description = get_bloginfo( 'description', 'display' );
             if ( $description || is_customize_preview() ) : ?>
                 <h2 class="site-description"><?php echo $description; /* WPCS: xss ok. */ ?></h2>

--- a/header-parts/sitebar.php
+++ b/header-parts/sitebar.php
@@ -21,33 +21,20 @@
                 <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
                     <?php 
                     
-                    $bases = array(
-                        'https://www.uri.edu',
-                        'http://quack.uri.edu'
-                        );
-                    
-                    $pages = array(
-                        '/admissions',
-                        '/academics',
-                        '/research',
-                        '/campus-life',
-                        '/about'
-                        );
-                    
-                    $url = get_permalink();
-                    
-                    $usetitle = false;
-                    foreach($bases as $b) {
-                        foreach($pages as $p) {
-                            $test = $b . $p . '/';
-                            if ($url == $test) {
-                                $usetitle = true;
-                                break;
-                            }
+                    $site_url = get_site_url();
+                    $site_permalink = get_permalink();
+                                        
+                    $alt_title_whitelist = explode(PHP_EOL, get_option('site_header_alternate_titles') );
+                                        
+                    $use_alt_title = false;
+                    foreach($alt_title_whitelist as $a) {
+                        if ($site_url . $a == $site_permalink || $site_url . $a . '/' == $site_permalink ) {
+                            $use_alt_title = true;
+                            break;
                         }
                     }
-                    
-                    if ($usetitle) {
+
+                    if ($use_alt_title) {
                         the_title();
                     } else {
                         bloginfo( 'name' );

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -182,9 +182,26 @@ function uri_modern_options_site_header($wp_customize) {
         'site_header_alternate_titles',
         array(
             'section' => 'header_image',
-            'label' => __( 'Alternate Site Title', 'uri' ),
-            'description' => __( 'Use the page title instead of the site title on these pages', 'uri' ),
+            'label' => __( 'Use page title for site name', 'uri' ),
+            'description' => __( 'Use the page title instead of the site name on these pages.  List each URL on a separate line (e.g. /about)', 'uri' ),
             'type' => 'textarea'
+        )
+    ) );
+    
+    $wp_customize->add_setting( 'site_header_alternate_titles_hide_tagline', array(
+        'default' => '',
+        'type' => 'option',
+        'sanitize_callback' => 'uri_modern_validate_checkbox'
+    ) );
+    
+    $wp_customize->add_control( new WP_Customize_Control( 
+	   $wp_customize, 
+        'site_header_alternate_titles_hide_tagline',
+        array(
+            'section' => 'header_image',
+            'label' => __( 'Hide alternate title taglines', 'uri' ),
+            'description' => __( 'Check to hide the header tagline on pages that display the alternate site name.  Note: This will have no effect while the Customizer is open', 'uri' ),
+            'type' => 'checkbox'
         )
     ) );
     

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -149,7 +149,7 @@ function uri_modern_options_social_media($wp_customize) {
 }
 
 /**
- * Creates options for site header
+ * Creates options for site header and footer
  *
  * @param WP_Customize_Manager $wp_customize Theme Customizer object.
  */
@@ -169,6 +169,22 @@ function uri_modern_options_site_header($wp_customize) {
             'label' => __( 'Use light colors', 'uri' ),
             'description' => __( 'Use light colors for header text and social media icons.  Check when using most background images.', 'uri' ),
             'type' => 'checkbox'
+        )
+    ) );
+    
+    $wp_customize->add_setting( 'site_header_alternate_titles', array(
+        'default' => '',
+        'type' => 'option'
+    ) );
+    
+    $wp_customize->add_control( new WP_Customize_Control( 
+	   $wp_customize, 
+        'site_header_alternate_titles',
+        array(
+            'section' => 'header_image',
+            'label' => __( 'Alternate Site Title', 'uri' ),
+            'description' => __( 'Use the page title instead of the site title on these pages', 'uri' ),
+            'type' => 'textarea'
         )
     ) );
     


### PR DESCRIPTION
Add Customizer options for using the page title in place of the site name in the header, as well as controlling whether to display the tagline in those cases too.