### PR TITLE
Release 1.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,13 @@
 
 URI Modern is a WordPress theme designed for the University of Rhode Island. It's designed to replace all themes currently being used on the university's websites, and unify the online brand and experience. 
 
-## What's new in 1.0.4
+## What's new in 1.0.5
 
-URI Modern 1.0.4 is a bug fix release.
+URI Modern 1.0.5 is a bug fix release.
 
-* Adds support for search results filtering
-* Makes minor adjustments to certain [component library](https://github.com/uriweb/uri-component-library) styles
-* Improves honoring of WordPress image sizes and alignment
-* Descendants of `fullwidth` class elements are now also full width
-* Fixes issues related to widget area compatibility on pages with a Stage
-* Other code/development housekeeping
+* Shortens the default breadcrumb prepend to "URI"
 
-For complete details, see the [commit history](https://github.com/uriweb/uri-modern/pull/115/commits) and the [issue tracker](https://github.com/uriweb/uri-modern/issues). 
+For complete details, see the [commit history](https://github.com/uriweb/uri-modern/pull/117/commits) and the [issue tracker](https://github.com/uriweb/uri-modern/issues). 
 
 ## How do I get set up?
 

--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ Contributors: Brandon Fuller, John Pennypacker
 Tags: themes  
 Requires at least: 4.0  
 Tested up to: 4.9  
-Stable tag: 1.0.4  
+Stable tag: 1.0.5  

--- a/inc/get-breadcrumbs.php
+++ b/inc/get-breadcrumbs.php
@@ -12,7 +12,7 @@ function uri_modern_breadcrumbs() {
 	$crumbs  = array();
 
 	$option_val = get_option( 'breadcrumbs_prepend' );
-	$default = 'The University of Rhode Island' == get_bloginfo( 'name' ) ? '' : '[The University of Rhode Island](https://www.uri.edu)';
+	$default = 'The University of Rhode Island' == get_bloginfo( 'name' ) ? '' : '[URI](https://www.uri.edu)';
 	$prepend = empty( $option_val ) ? array( $default ) : explode( "\n", $option_val );
 
 	foreach ( $prepend as $l ) {

--- a/js/script.min.js
+++ b/js/script.min.js
@@ -4,13 +4,13 @@ Theme URI: https://www.uri.edu
 Author: University of Rhode Island
 Author URI: https://today.uri.edu
 Description: URI Modern is a WordPress theme designed for the University of Rhode Island. It's designed to replace all themes currently being used on the university's websites, and unify the online brand and experience.
-Version: 1.0.4
+Version: 1.0.5
 License: GPL-3.0
 License URI: http://www.gnu.org/licenses/gpl.html
 Text Domain: uri
 Tags: education, theme-options
 
-@version v1.0.4
+@version v1.0.5
 @author Brandon Fuller <bjcfuller@uri.edu>
 @author John Pennypacker <jpennypacker@uri.edu>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uri-modern",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "URI Modern is a WordPress theme designed for the University of Rhode Island. It's designed to replace all themes currently being used on the university's websites, and unify the online brand and experience.",
   "themeName": "URI Modern",
   "textDomain": "uri",

--- a/style.css
+++ b/style.css
@@ -4,13 +4,13 @@ Theme URI: https://www.uri.edu
 Author: University of Rhode Island
 Author URI: https://today.uri.edu
 Description: URI Modern is a WordPress theme designed for the University of Rhode Island. It's designed to replace all themes currently being used on the university's websites, and unify the online brand and experience.
-Version: 1.0.4
+Version: 1.0.5
 License: GPL-3.0
 License URI: http://www.gnu.org/licenses/gpl.html
 Text Domain: uri
 Tags: education, theme-options
 
-@version v1.0.4
+@version v1.0.5
 @author Brandon Fuller <bjcfuller@uri.edu>
 @author John Pennypacker <jpennypacker@uri.edu>
 


### PR DESCRIPTION
## What's new in 1.0.5

URI Modern 1.0.5 is a bug fix release.

* Shortens the default breadcrumb prepend to "URI"

