### PR TITLE
Use getter instead of printer in single-parts.php template

### DIFF
--- a/template-parts/single-program.php
+++ b/template-parts/single-program.php
@@ -165,7 +165,7 @@ get_header();
 
 						<?php
 						$curriculum_sheets = get_field( 'curriculum_sheets' );
-						$curriculum_default_link = 'https://' . uri_modern_the_domain( 'web' ) . '/advising/curriculum-sheets-all/';
+						$curriculum_default_link = 'https://' . uri_modern_get_the_domain( 'web' ) . '/advising/curriculum-sheets-all/';
 						if ( ( null != $curriculum_sheets || ! empty( $curriculum_sheets ) ) && $curriculum_default_link != $curriculum_sheets ) {
 										echo '<div class="advising">';
 										echo '<a href="' . $curriculum_sheets . '"><span class="icon"></span>Advising</a>';


### PR DESCRIPTION
## Changes

The `single-program.php` template part inadvertently uses a `uri_modern_the_domain()` instead of `uri_modern_get_the_domain()`, which causes the domain to be echoed into the rendered HTML.

![Biotechnology B S 2022-08-26 at 8 33 52 AM  – Programs - Google Chrome](https://user-images.githubusercontent.com/83631/186904302-87d4dadf-9ccf-4fc8-815e-f57254c35c5b.jpeg)

## Notes

This issue was identified during UAT of the migration.
