### PR TITLE
Merge dev-limit-blocks-by-role into develop

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -558,9 +558,9 @@ function uri_modern_has_admin_privilages() {
 	$admin = false;
 
 	global $current_user;
-	$role = array_shift( $current_user->roles );
+	$role = $current_user->caps['administrator'];
 
-	if ( 'administrator' == $role || 'Webadmin' == $role ) {
+	if ( $role ) {
 		$admin = true;
 	}
 

--- a/inc/gutenberg.php
+++ b/inc/gutenberg.php
@@ -27,9 +27,9 @@ add_action( 'enqueue_block_editor_assets', 'uri_modern_gutenberg_scripts' );
  * @see https://wordpress.stackexchange.com/questions/379612/how-to-remove-the-core-embed-blocks-in-wordpress-5-6
  * @return arr
  */
-function uri_modern_allowed_blocks( $allowed_blocks, $post ) {
+function uri_modern_allowed_blocks( $allowed_blocks, $editor_context ) {
 
-	$blocks = array(
+	$allowed_blocks = array(
 		'core/block',
 		// ===== CORE - COMMON =====
 		'core/paragraph',
@@ -75,7 +75,7 @@ function uri_modern_allowed_blocks( $allowed_blocks, $post ) {
 	// Allow some blocks for admins only
 	if ( uri_modern_has_admin_privilages() ) {
 		array_push(
-			 $blocks,
+			 $allowed_blocks,
 			// ===== CORE - FORMATTING =====
 			'core/code',
 			// ===== CORE - WIDGETS =====
@@ -89,9 +89,9 @@ function uri_modern_allowed_blocks( $allowed_blocks, $post ) {
 		);
 	}
 
-	return $blocks;
+	return $allowed_blocks;
 }
-add_filter( 'allowed_block_types', 'uri_modern_allowed_blocks', 10, 2 );
+add_filter( 'allowed_block_types_all', 'uri_modern_allowed_blocks', 10, 2 );
 
 
 

--- a/inc/gutenberg.php
+++ b/inc/gutenberg.php
@@ -23,61 +23,40 @@ add_action( 'enqueue_block_editor_assets', 'uri_modern_gutenberg_scripts' );
 /**
  * Specifiy which core blocks are permitted.
  *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/core-blocks/
+ * @see https://wordpress.stackexchange.com/questions/379612/how-to-remove-the-core-embed-blocks-in-wordpress-5-6
  * @return arr
  */
 function uri_modern_allowed_blocks( $allowed_blocks, $post ) {
-	return array(
+
+	$blocks = array(
 		'core/block',
 		// ===== CORE - COMMON =====
 		'core/paragraph',
 		'core/image',
 		'core/heading',
-		// 'core/subhead',
 		'core/gallery',
 		'core/list',
-		// 'core/quote',
-		//'core/audio',
-		//'core/cover',
 		'core/file',
-		//'core/video',
 		// ===== CORE - FORMATTING =====
 		'core/table',
-		//'core/verse',
-		'core/code',
 		'core/freeform', // Classic
 		'core/html',
-		//'core/preformatted',
-		// 'core/pullquote',
 		// ===== CORE - LAYOUT =====
-		// 'core/button',
 		'core/columns',
 		'core/group',
 		'core/media-text',
-		//'core/more',
-		//'core/nextpage', // Page break
 		'core/separator',
 		'core/spacer',
 		// ===== CORE - WIDGETS =====
 		'core/shortcode',
-		//'core/archives',
-		//'core/categories',
-		//'core/latest-comments',
-		//'core/latest-posts',
-		'core/calendar',
-		'core/rss',
-		'core/search',
-		//'core/tag-cloud',
-		// ===== CORE - EMBEDS =====
-		//'core/embed', // @see https://wordpress.stackexchange.com/questions/379612/how-to-remove-the-core-embed-blocks-in-wordpress-5-6
 		// ===== URI - COMPONENT LIBRARY =====
-		'uri-cl/abstract',
 		'uri-cl/boxout',
 		'uri-cl/breakout',
 		'uri-cl/button',
 		'uri-cl/card',
 		'uri-cl/date',
 		'uri-cl/hero',
-		//'uri-cl/hero2', // Legacy hero registration (I think) -BF
 		'uri-cl/metric',
 		'uri-cl/menu',
 		'uri-cl/notice',
@@ -88,11 +67,29 @@ function uri_modern_allowed_blocks( $allowed_blocks, $post ) {
 		'uri-cl/tabs',
 		// ===== URI - MISC =====
 		'uri-courses/by-subject',
-		'uri/dynamic-metrics',
 		// ===== THIRD-PARTY =====
 		'gravityforms/form',
 		'ninja-tables/guten-block',
 	);
+
+	// Allow some blocks for admins only
+	if ( uri_modern_has_admin_privilages() ) {
+		array_push(
+			 $blocks,
+			// ===== CORE - FORMATTING =====
+			'core/code',
+			// ===== CORE - WIDGETS =====
+			'core/calendar',
+			'core/rss',
+			'core/search',
+			// ===== URI - COMPONENT LIBRARY =====
+			'uri-cl/abstract', // in beta
+			// ===== URI - MISC =====
+			'uri/dynamic-metrics', // in beta
+		);
+	}
+
+	return $blocks;
 }
 add_filter( 'allowed_block_types', 'uri_modern_allowed_blocks', 10, 2 );
 

--- a/inc/gutenberg.php
+++ b/inc/gutenberg.php
@@ -27,7 +27,7 @@ add_action( 'enqueue_block_editor_assets', 'uri_modern_gutenberg_scripts' );
  * @see https://wordpress.stackexchange.com/questions/379612/how-to-remove-the-core-embed-blocks-in-wordpress-5-6
  * @return arr
  */
-function uri_modern_allowed_blocks( $allowed_blocks, $editor_context ) {
+function uri_modern_allowed_blocks( $allowed_blocks, $post ) {
 
 	$allowed_blocks = array(
 		'core/block',
@@ -91,7 +91,7 @@ function uri_modern_allowed_blocks( $allowed_blocks, $editor_context ) {
 
 	return $allowed_blocks;
 }
-add_filter( 'allowed_block_types_all', 'uri_modern_allowed_blocks', 10, 2 );
+add_filter( 'allowed_block_types', 'uri_modern_allowed_blocks', 10, 2 );
 
 
 


### PR DESCRIPTION
Limit certain blocks to admin use only.  The `allowed_block_types` hook will need to be rewritten whenever we upgrade to v5.8 or later (see [allowed_block_types_all](https://developer.wordpress.org/reference/hooks/allowed_block_types_all/)).