### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/.codesniffer.ruleset.xml
+++ b/.codesniffer.ruleset.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="WordPress Theme Coding Standards">
-	<!-- See https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+	<!-- See https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset -->
 	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/develop/WordPress-Core/ruleset.xml -->
 
 	<!-- Set a description for this ruleset. -->

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,13 +62,13 @@ before_script:
     # Create WordPress database.
     - mysql -e 'CREATE DATABASE wordpress_test;'
     # Install CodeSniffer for WordPress Coding Standards checks.
-    - mkdir php-codesniffer && curl -L https://github.com/squizlabs/PHP_CodeSniffer/archive/master.tar.gz | tar xz --strip-components=1 -C php-codesniffer
+    - mkdir php-codesniffer && curl -L https://github.com/PHPCSStandards/PHP_CodeSniffer/archive/master.tar.gz | tar xz --strip-components=1 -C php-codesniffer
     # Install WordPress Coding Standards.
     - mkdir wordpress-coding-standards && curl -L https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/archive/master.tar.gz | tar xz --strip-components=1 -C wordpress-coding-standards
     # Hop into CodeSniffer directory.
     - cd php-codesniffer
     # Set install path for WordPress Coding Standards
-    # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
+    # @link https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
     - bin/phpcs --config-set installed_paths ../wordpress-coding-standards
     # Hop into themes directory.
     - cd $theme_dir

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,12 +140,12 @@ After you've written some code and are thinking about [submitting a pull request
 You'll need to install some prerequisites first:
 
 * [Composer](https://getcomposer.org), which is used to install PHP CodeSniffer
-* [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), which is used to test code locally
+* [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), which is used to test code locally
 * [WordPress Coding Standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#installation), a collection of PHP CodeSniffer rules for WordPress
 
 #### Install Composer
 
-There are a lot of PHP dependency managers out there, so if you have one you like or are already using, feel free to [install PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer#installation) that way.
+There are a lot of PHP dependency managers out there, so if you have one you like or are already using, feel free to [install PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer#installation) that way.
 
 For this guide, we'll use Composer.  Here's how to [install it](https://getcomposer.org/download/).
 
@@ -158,7 +158,7 @@ $ mv composer.phar /usr/local/bin/composer
 
 #### Install PHP CodeSniffer
 
-Install PHP CodeSniffer using their [instructions for Composer](https://github.com/squizlabs/PHP_CodeSniffer#composer).
+Install PHP CodeSniffer using their [instructions for Composer](https://github.com/PHPCSStandards/PHP_CodeSniffer#composer).
 
 Essentially, this involves running:
 
@@ -246,7 +246,7 @@ To use the custom ruleset included in URI Modern, set the `--standard` arguement
 $ phpcs --standard=.codesniffer.ruleset.xml some_file.php
 ```
 
-You can check out all the PHP CodeSniffer [config options](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options) on their [wiki](https://github.com/squizlabs/PHP_CodeSniffer/wiki).
+You can check out all the PHP CodeSniffer [config options](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Configuration-Options) on their [wiki](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki).
 
 ### Git Model
 


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932

Note: Please consider using a different branch when downloading PHPCS. `master` is not used anymore.